### PR TITLE
WriteDescriptiveListItem() missing closing tags for dt and dd

### DIFF
--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -335,9 +335,10 @@ func (w *HTMLWriter) WriteDescriptiveListItem(di DescriptiveListItem) {
 	} else {
 		w.WriteString("?")
 	}
+	w.WriteString("</dt>\n")
 	w.WriteString("<dd>\n")
 	WriteNodes(w, di.Details...)
-	w.WriteString("<dd>\n")
+	w.WriteString("</dd>\n")
 }
 
 func (w *HTMLWriter) WriteParagraph(p Paragraph) {


### PR DESCRIPTION
I have written an org-mode file which has a description list like this:
desc.org
```
- term :: term one
- term2 :: term two
````

```
$ ./go-org desc.org html
<dl>
<dt>
term<dd>
<p>
term one
</p>
<dd>
<dt>
term2<dd>
<p>
term two
</p>
<dd>
</dl>
```

I found it missing `</dt>` and `</dd>` tag, after fixing it, it seems work as I expected:
```
$ ./go-org desc.org html
<dl>
<dt>
term</dt>
<dd>
<p>
term one
</p>
</dd>
<dt>
term2</dt>
<dd>
<p>
term two
</p>
</dd>
</dl>
```

