### PR TITLE
WriteDescriptiveListItem() missing closing tags for dt and dd

### DIFF
--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -335,9 +335,10 @@ func (w *HTMLWriter) WriteDescriptiveListItem(di DescriptiveListItem) {
 	} else {
 		w.WriteString("?")
 	}
+	w.WriteString("</dt>\n")
 	w.WriteString("<dd>\n")
 	WriteNodes(w, di.Details...)
-	w.WriteString("<dd>\n")
+	w.WriteString("</dd>\n")
 }
 
 func (w *HTMLWriter) WriteParagraph(p Paragraph) {

--- a/org/testdata/lists.html
+++ b/org/testdata/lists.html
@@ -109,26 +109,30 @@ descriptive lists
 </p>
 <dl>
 <dt class="unchecked">
-term<dd>
+term</dt>
+<dd>
 <p>
 details
 continued details
 </p>
-<dd>
+</dd>
 <dt class="unchecked">
-?<dd>
+?</dt>
+<dd>
 <p>
 details without a term
 </p>
-<dd>
+</dd>
 <dt class="checked">
-term<dd>
+term</dt>
+<dd>
 <p>
 details on a new line
 </p>
-<dd>
+</dd>
 <dt>
-term<dd>
+term</dt>
+<dd>
 <p>
 details on a new line (with an empty line in between)
 <strong>continued</strong>
@@ -140,7 +144,7 @@ echo &#34;Hello World!&#34;
 </pre>
 </div>
 </div>
-<dd>
+</dd>
 </dl>
 <p>
 some list termination tests
@@ -207,31 +211,35 @@ ordered 2
 </ol>
 <dl>
 <dt>
-unordered descriptive<dd>
+unordered descriptive</dt>
+<dd>
 <p>
 1
 </p>
-<dd>
+</dd>
 <dt>
-unordered descriptive<dd>
+unordered descriptive</dt>
+<dd>
 <p>
 2
 </p>
-<dd>
+</dd>
 </dl>
 <dl>
 <dt>
-ordered descriptive<dd>
+ordered descriptive</dt>
+<dd>
 <p>
 1
 </p>
-<dd>
+</dd>
 <dt>
-ordered descriptive<dd>
+ordered descriptive</dt>
+<dd>
 <p>
 2
 </p>
-<dd>
+</dd>
 </dl>
 <ul>
 <li>


### PR DESCRIPTION
I have written an org-mode file which has a description list like this:
desc.org
```
- term :: term one
- term2 :: term two
````

```
$ ./go-org desc.org html
<dl>
<dt>
term<dd>
<p>
term one
</p>
<dd>
<dt>
term2<dd>
<p>
term two
</p>
<dd>
</dl>
```

I found it missing `</dt>` and `</dd>` tag, after fixing it, it seems work as I expected:
```
$ ./go-org desc.org html
<dl>
<dt>
term</dt>
<dd>
<p>
term one
</p>
</dd>
<dt>
term2</dt>
<dd>
<p>
term two
</p>
</dd>
</dl>
```

I'm not sure whehter should I also change the testdata/list.html, hope this pull request help.