### PR TITLE
html: Improve footnote rendering (output more similar to blackfriday)

### DIFF
--- a/etc/style.css
+++ b/etc/style.css
@@ -94,10 +94,7 @@ figcaption {
   text-align: center;
   color: grey; }
 
-.footnote-definition sup {
-  float: left; }
-
-.footnote-definition .footnote-body {
+.footnote-definition {
   margin: 1em 0;
   padding: 0 1em;
   border: 1px solid rgba(250, 100, 50, 0.3);

--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -149,7 +149,7 @@ func (w *HTMLWriter) WriteFootnotes(d *Document) {
 	}
 	w.WriteString(`<div class="footnotes">` + "\n")
 	w.WriteString(`<hr class="footnotes-separatator">` + "\n")
-	w.WriteString(`<div class="footnote-definitions">` + "\n")
+	w.WriteString(`<ol class="footnote-definitions">` + "\n")
 	for i, definition := range w.footnotes.list {
 		id := i + 1
 		if definition == nil {
@@ -162,13 +162,14 @@ func (w *HTMLWriter) WriteFootnotes(d *Document) {
 			w.log.Printf("Missing footnote definition for [fn:%s] (#%d)", name, id)
 			continue
 		}
-		w.WriteString(`<div class="footnote-definition">` + "\n")
-		w.WriteString(fmt.Sprintf(`<sup id="footnote-%d"><a href="#footnote-reference-%d">%d</a></sup>`, id, id, id) + "\n")
+		w.WriteString(fmt.Sprintf(`<li id="footnote-%d" class="footnote-definition">`, id) + "\n")
 		w.WriteString(`<div class="footnote-body">` + "\n")
 		WriteNodes(w, definition.Children...)
-		w.WriteString("</div>\n</div>\n")
+		w.WriteString("</div>\n")
+		w.WriteString(fmt.Sprintf(`<sup><a class="footnote-return" href="#footnote-reference-%d">%d</a></sup>`, id, id) + "\n")
+		w.WriteString("</li>\n")
 	}
-	w.WriteString("</div>\n</div>\n")
+	w.WriteString("</ol>\n</div>\n")
 }
 
 func (w *HTMLWriter) WriteOutline(d *Document) {

--- a/org/testdata/footnotes.html
+++ b/org/testdata/footnotes.html
@@ -53,9 +53,8 @@ this is not part of <sup class="footnote-reference"><a id="footnote-reference-8"
 </p>
 <div class="footnotes">
 <hr class="footnotes-separatator">
-<div class="footnote-definitions">
-<div class="footnote-definition">
-<sup id="footnote-1"><a href="#footnote-reference-1">1</a></sup>
+<ol class="footnote-definitions">
+<li id="footnote-1" class="footnote-definition">
 <div class="footnote-body">
 <p>
 <a href="https://www.example.com">https://www.example.com</a>
@@ -108,57 +107,58 @@ and tables
 </li>
 </ul>
 </div>
-</div>
-<div class="footnote-definition">
-<sup id="footnote-2"><a href="#footnote-reference-2">2</a></sup>
+<sup><a class="footnote-return" href="#footnote-reference-1">1</a></sup>
+</li>
+<li id="footnote-2" class="footnote-definition">
 <div class="footnote-body">
 <p>
 Footnotes break after two consecutive empty lines - just like paragraphs - see <a href="https://orgmode.org/worg/dev/org-syntax.html.">https://orgmode.org/worg/dev/org-syntax.html.</a>
 This shouldn&#39;t happen when the definition line and the line after that are empty.
 </p>
 </div>
-</div>
-<div class="footnote-definition">
-<sup id="footnote-3"><a href="#footnote-reference-3">3</a></sup>
+<sup><a class="footnote-return" href="#footnote-reference-2">2</a></sup>
+</li>
+<li id="footnote-3" class="footnote-definition">
 <div class="footnote-body">
 <p>
 yolo
 </p>
 </div>
-</div>
-<div class="footnote-definition">
-<sup id="footnote-4"><a href="#footnote-reference-4">4</a></sup>
+<sup><a class="footnote-return" href="#footnote-reference-3">3</a></sup>
+</li>
+<li id="footnote-4" class="footnote-definition">
 <div class="footnote-body">
 <p>
 the inline footnote definition
 </p>
 </div>
-</div>
-<div class="footnote-definition">
-<sup id="footnote-5"><a href="#footnote-reference-5">5</a></sup>
+<sup><a class="footnote-return" href="#footnote-reference-4">4</a></sup>
+</li>
+<li id="footnote-5" class="footnote-definition">
 <div class="footnote-body">
 <p>
 the anonymous inline footnote definition
 </p>
 </div>
-</div>
-<div class="footnote-definition">
-<sup id="footnote-6"><a href="#footnote-reference-6">6</a></sup>
+<sup><a class="footnote-return" href="#footnote-reference-5">5</a></sup>
+</li>
+<li id="footnote-6" class="footnote-definition">
 <div class="footnote-body">
 <p>
 so this definition will not be at the end of this section in the exported document.
 Rather, it will be somewhere down below in the footnotes section.
 </p>
 </div>
-</div>
-<div class="footnote-definition">
-<sup id="footnote-8"><a href="#footnote-reference-8">8</a></sup>
+<sup><a class="footnote-return" href="#footnote-reference-6">6</a></sup>
+</li>
+<li id="footnote-8" class="footnote-definition">
 <div class="footnote-body">
 <p>
 There&#39;s multiple reasons for that. Among others, doing so requires i18n (to recognize the section) and silently
 hides content before and after the footnotes.
 </p>
 </div>
-</div>
-</div>
+<sup><a class="footnote-return" href="#footnote-reference-8">8</a></sup>
+</li>
+</ol>
 </div>

--- a/org/testdata/footnotes_in_headline.html
+++ b/org/testdata/footnotes_in_headline.html
@@ -9,9 +9,8 @@ Title <sup class="footnote-reference"><a id="footnote-reference-1" href="#footno
 </h1>
 <div class="footnotes">
 <hr class="footnotes-separatator">
-<div class="footnote-definitions">
-<div class="footnote-definition">
-<sup id="footnote-1"><a href="#footnote-reference-1">1</a></sup>
+<ol class="footnote-definitions">
+<li id="footnote-1" class="footnote-definition">
 <div class="footnote-body">
 <p>
 this test file just exists to reproduce a bug with footnotes in headlines - that only happens in very specific circumstances.
@@ -42,6 +41,7 @@ We can thus end up with a footnote being in the mapping but not the slice - and 
 </li>
 </ul>
 </div>
-</div>
-</div>
+<sup><a class="footnote-return" href="#footnote-reference-1">1</a></sup>
+</li>
+</ol>
 </div>

--- a/org/testdata/misc.html
+++ b/org/testdata/misc.html
@@ -485,9 +485,8 @@ Footnotes
 </h1>
 <div class="footnotes">
 <hr class="footnotes-separatator">
-<div class="footnote-definitions">
-<div class="footnote-definition">
-<sup id="footnote-1"><a href="#footnote-reference-1">1</a></sup>
+<ol class="footnote-definitions">
+<li id="footnote-1" class="footnote-definition">
 <div class="footnote-body">
 <p>
 a footnote <em>with</em> <strong>markup</strong>
@@ -505,14 +504,15 @@ because that&#39;s possible
 </li>
 </ul>
 </div>
-</div>
-<div class="footnote-definition">
-<sup id="footnote-2"><a href="#footnote-reference-2">2</a></sup>
+<sup><a class="footnote-return" href="#footnote-reference-1">1</a></sup>
+</li>
+<li id="footnote-2" class="footnote-definition">
 <div class="footnote-body">
 <p>
 that also goes for <strong>inline</strong> footnote <em>definitions</em>
 </p>
 </div>
-</div>
-</div>
+<sup><a class="footnote-return" href="#footnote-reference-2">2</a></sup>
+</li>
+</ol>
 </div>


### PR DESCRIPTION
this is just so we have something to start with - check the branch out and run `make generate-gh-pages` + open `gh-pages/index.html` in a browser if you want to look at the output.

Now that I'm actually looking at the output... blackfriday seems to have an unwrapped footnote-body - e.g. `foo` rather than `<p>foo</p>` - we can't easily put the footnote link on the same line as the body. The current way of putting it on the left is done with `float: left` + a margin which is also a hack - so this isn't as easy / obvious as i thought :D :see_no_evil: 

-----

blackfriday renders footnotes into an ol list - we can do that as well and
hopefully make it a little easier for hugo users to reuse premade (i.e. adapted
to the default renderer, which is blackfriday) themes.

blackfriday output:

    <sup class="footnote-ref" id="fnref:1"><a href="#fn:1">1</a></sup></p>

    <div class="footnotes">
      <hr>
      <ol>
        <li id="fn:1">foobar
          <a class="footnote-return" href="#fnref:1"><sup>[return]</sup></a></li>
      </ol>
    </div>

updated go-org output

    <sup class="footnote-reference"><a id="footnote-reference-1" href="#footnote-1">1</a></sup>

    <div class="footnotes">
      <hr class="footnotes-separatator">
      <ol class="footnote-definitions">
        <li id="footnote-1" class="footnote-definition">
          <sup><a class="footnote-return" href="#footnote-reference-1">1</a></sup>
          <div class="footnote-body"><p>foobar</p></div>
        </li>
      </ol>
    </div>

notable differences:
- blackfriday swaps from sup>a in the footnote reference to a>sup in the
  footnote definition
- go-org makes more information available via
  css-classes (e.g. .footnote-separator) - this should not affect blackfriday
  themes
- go-org puts the footnote body in a separate div in the spirit of making
  more information available in the output