### PR TITLE
HTML export headlines offset

### DIFF
--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -5,6 +5,7 @@ import (
 	"html"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -214,7 +215,18 @@ func (w *HTMLWriter) WriteHeadline(h Headline) {
 		}
 	}
 
-	w.WriteString(fmt.Sprintf(`<h%d id="%s">`, h.Lvl, h.ID()) + "\n")
+	level := h.Lvl
+	lvlOffsetVal := w.document.Get("EXPORT_LEVEL_OFFSET")
+	if lvlOffsetVal != "" {
+		lvlOffset, err := strconv.Atoi(lvlOffsetVal)
+		if err != nil {
+			lvlOffset = 0
+		}
+		if level+lvlOffset > 0 {
+			level += lvlOffset
+		}
+	}
+	w.WriteString(fmt.Sprintf(`<h%d id="%s">`, level, h.ID()) + "\n")
 	if w.document.GetOption("todo") && h.Status != "" {
 		w.WriteString(fmt.Sprintf(`<span class="todo">%s</span>`, h.Status) + "\n")
 	}


### PR DESCRIPTION
Hello.

I'm using go-org with Hugo and want to use `#+TITLE` as h1 heading and to shift all other headings by 1. You can do this using ox-hugo (`EXPORT_HUGO_LEVEL_OFFSET`).

So maybe it will be a nice feature.