### PR TITLE
Add support for escaping in literal examples

### DIFF
--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -54,6 +54,7 @@ var listItemStatuses = map[string]string{
 }
 
 var cleanHeadlineTitleForHTMLAnchorRegexp = regexp.MustCompile(`</?a[^>]*>`) // nested a tags are not valid HTML
+var literalExampleRegexp = regexp.MustCompile(`^(\s*)(,)(#\+|\*)`)
 
 func NewHTMLWriter() *HTMLWriter {
 	defaultConfig := New()
@@ -247,9 +248,13 @@ func (w *HTMLWriter) WriteHeadline(h Headline) {
 	WriteNodes(w, h.Children...)
 }
 
+func trimEscapingInLiteralExamples (line string) string {
+	return literalExampleRegexp.ReplaceAllString(line, "$1$3")
+}
+
 func (w *HTMLWriter) WriteText(t Text) {
 	if !w.htmlEscape {
-		w.WriteString(t.Content)
+		w.WriteString(trimEscapingInLiteralExamples(t.Content))
 	} else if w.document.GetOption("e") == "nil" || t.IsRaw {
 		w.WriteString(html.EscapeString(t.Content))
 	} else {

--- a/org/testdata/blocks.html
+++ b/org/testdata/blocks.html
@@ -16,6 +16,9 @@ hello
 block caption
 </figcaption>
 </figure>
+<pre class="example">
+  * I am no real headline
+</pre>
 <div class="src src-text">
 <div class="highlight">
 <pre>

--- a/org/testdata/blocks.html
+++ b/org/testdata/blocks.html
@@ -19,6 +19,15 @@ block caption
 <pre class="example">
   * I am no real headline
 </pre>
+<div class="src src-org">
+<div class="highlight">
+<pre>
+  #+BEGIN_SRC shell :exports results
+  hledger balancesheet -f sample.journal -O csv --empty --value
+  #+END_SRC
+</pre>
+</div>
+</div>
 <div class="src src-text">
 <div class="highlight">
 <pre>

--- a/org/testdata/blocks.org
+++ b/org/testdata/blocks.org
@@ -9,6 +9,12 @@ function hello {
 hello
 #+END_SRC
 
+# Escaping in literal examples, see
+# https://orgmode.org/manual/Literal-Examples.html#Literal-Examples
+#+BEGIN_EXAMPLE
+  ,* I am no real headline
+#+END_EXAMPLE
+
 #+BEGIN_SRC
 a source block without a language
 #+END_SRC

--- a/org/testdata/blocks.org
+++ b/org/testdata/blocks.org
@@ -15,6 +15,14 @@ hello
   ,* I am no real headline
 #+END_EXAMPLE
 
+# Nested code blocks, see
+# https://github.com/niklasfasching/go-org/issues/28
+#+BEGIN_SRC org
+  ,#+BEGIN_SRC shell :exports results
+  hledger balancesheet -f sample.journal -O csv --empty --value
+  ,#+END_SRC
+#+END_SRC
+
 #+BEGIN_SRC
 a source block without a language
 #+END_SRC

--- a/org/testdata/blocks.pretty_org
+++ b/org/testdata/blocks.pretty_org
@@ -9,6 +9,12 @@ function hello {
 hello
 #+END_SRC
 
+# Escaping in literal examples, see
+# https://orgmode.org/manual/Literal-Examples.html#Literal-Examples
+#+BEGIN_EXAMPLE
+  ,* I am no real headline
+#+END_EXAMPLE
+
 #+BEGIN_SRC
 a source block without a language
 #+END_SRC

--- a/org/testdata/blocks.pretty_org
+++ b/org/testdata/blocks.pretty_org
@@ -15,6 +15,14 @@ hello
   ,* I am no real headline
 #+END_EXAMPLE
 
+# Nested code blocks, see
+# https://github.com/niklasfasching/go-org/issues/28
+#+BEGIN_SRC org
+  ,#+BEGIN_SRC shell :exports results
+  hledger balancesheet -f sample.journal -O csv --empty --value
+  ,#+END_SRC
+#+END_SRC
+
 #+BEGIN_SRC
 a source block without a language
 #+END_SRC


### PR DESCRIPTION
This PR adds support for escaping in literal examples, i.e. it fixes #28.

It does this simply by dropping the escaping character in the html writer. The parsing and the org writer are not changed.

I also added a few tests and they all pass