### PR TITLE
Make ORG-mode drawer ":end:" case-insensitivie

### DIFF
--- a/org/drawer.go
+++ b/org/drawer.go
@@ -15,7 +15,7 @@ type PropertyDrawer struct {
 }
 
 var beginDrawerRegexp = regexp.MustCompile(`^(\s*):(\S+):\s*$`)
-var endDrawerRegexp = regexp.MustCompile(`^(\s*):END:\s*$`)
+var endDrawerRegexp = regexp.MustCompile(`(?i)^(\s*):END:\s*$`)
 var propertyRegexp = regexp.MustCompile(`^(\s*):(\S+):(\s+(.*)$|$)`)
 
 func lexDrawer(line string) (token, bool) {

--- a/org/testdata/headlines.org
+++ b/org/testdata/headlines.org
@@ -18,7 +18,7 @@ we can link to headlines that define a custom_id: [[#this-will-be-the-id-of-the-
 Still outside the drawer
 :DRAWERNAME:
 This is inside the drawer
-:END:
+:end:
 Still outside the drawer
 * CUSTOM headline with custom status
 it's possible to use =#+SETUPFILE= - in this case the setup file contains the following

--- a/org/testdata/misc.html
+++ b/org/testdata/misc.html
@@ -162,7 +162,7 @@ we can link to headlines that define a custom_id: [[#this-will-be-the-id-of-the-
 Still outside the drawer
 :DRAWERNAME:
 This is inside the drawer
-:END:
+:end:
 Still outside the drawer
 * CUSTOM headline with custom status
 it&#39;s possible to use =#+SETUPFILE= - in this case the setup file contains the following


### PR DESCRIPTION
Emacs org-mode can create/udpate drawers with lower-case `:end:` indicators.