### PR TITLE
For simple list items, don't wrap in <p> tags

### DIFF
--- a/org/testdata/blocks.html
+++ b/org/testdata/blocks.html
@@ -68,12 +68,8 @@ note that /inline/ *markup* ignored
 <p>
 blocks like the quote block parse their content and can contain</p>
 <ul>
-<li>
-<p>lists</p>
-</li>
-<li>
-<p>inline <em>markup</em></p>
-</li>
+<li>lists</li>
+<li>inline <em>markup</em></li>
 <li>
 <p>tables</p>
 <table>
@@ -90,9 +86,7 @@ blocks like the quote block parse their content and can contain</p>
 </tbody>
 </table>
 </li>
-<li>
-<p>paragraphs</p>
-</li>
+<li>paragraphs</li>
 <li>
 <p>…</p>
 <p>

--- a/org/testdata/footnotes.html
+++ b/org/testdata/footnotes.html
@@ -12,25 +12,13 @@ Using some footnotes
 </h2>
 <div id="outline-text-headline-1" class="outline-text-2">
 <ul>
-<li>
-<p>normal footnote reference <sup class="footnote-reference"><a id="footnote-reference-1" href="#footnote-1">1</a></sup> <sup class="footnote-reference"><a id="footnote-reference-2" href="#footnote-2">2</a></sup> <sup class="footnote-reference"><a id="footnote-reference-3" href="#footnote-3">3</a></sup> (footnote names can be anything in the format <code class="verbatim">[\w-]</code>)</p>
-</li>
-<li>
-<p>further references to the same footnote should not <sup class="footnote-reference"><a id="footnote-reference-1" href="#footnote-1">1</a></sup> render duplicates in the footnote list</p>
-</li>
-<li>
-<p>inline footnotes are also supported via <sup class="footnote-reference"><a id="footnote-reference-4" href="#footnote-4">4</a></sup>.</p>
-</li>
-<li>
-<p>anonymous inline footnotes are also supported via <sup class="footnote-reference"><a id="footnote-reference-5" href="#footnote-5">5</a></sup>.</p>
-</li>
-<li>
-<p>Footnote definitions are not printed where they appear.
-Rather, they are gathered and exported at the end of the document in the footnote section. <sup class="footnote-reference"><a id="footnote-reference-6" href="#footnote-6">6</a></sup></p>
-</li>
-<li>
-<p>footnotes that reference a non-existant definition are rendered but log a warning <sup class="footnote-reference"><a id="footnote-reference-7" href="#footnote-7">7</a></sup></p>
-</li>
+<li>normal footnote reference <sup class="footnote-reference"><a id="footnote-reference-1" href="#footnote-1">1</a></sup> <sup class="footnote-reference"><a id="footnote-reference-2" href="#footnote-2">2</a></sup> <sup class="footnote-reference"><a id="footnote-reference-3" href="#footnote-3">3</a></sup> (footnote names can be anything in the format <code class="verbatim">[\w-]</code>)</li>
+<li>further references to the same footnote should not <sup class="footnote-reference"><a id="footnote-reference-1" href="#footnote-1">1</a></sup> render duplicates in the footnote list</li>
+<li>inline footnotes are also supported via <sup class="footnote-reference"><a id="footnote-reference-4" href="#footnote-4">4</a></sup>.</li>
+<li>anonymous inline footnotes are also supported via <sup class="footnote-reference"><a id="footnote-reference-5" href="#footnote-5">5</a></sup>.</li>
+<li>Footnote definitions are not printed where they appear.
+Rather, they are gathered and exported at the end of the document in the footnote section. <sup class="footnote-reference"><a id="footnote-reference-6" href="#footnote-6">6</a></sup></li>
+<li>footnotes that reference a non-existant definition are rendered but log a warning <sup class="footnote-reference"><a id="footnote-reference-7" href="#footnote-7">7</a></sup></li>
 </ul>
 </div>
 </div>
@@ -52,9 +40,7 @@ this is not part of <sup class="footnote-reference"><a id="footnote-reference-8"
 <div class="footnote-body">
 <p><a href="https://www.example.com">https://www.example.com</a></p>
 <ul>
-<li>
-<p>footnotes can contain <strong>markup</strong></p>
-</li>
+<li>footnotes can contain <strong>markup</strong></li>
 <li>
 <p>and other elements</p>
 <ul>

--- a/org/testdata/footnotes_in_headline.html
+++ b/org/testdata/footnotes_in_headline.html
@@ -18,20 +18,12 @@ Title <sup class="footnote-reference"><a id="footnote-reference-1" href="#footno
 <p>this test file just exists to reproduce a bug with footnotes in headlines - that only happens in very specific circumstances.
 The TLDR is:</p>
 <ul>
-<li>
-<p>HTMLWriter.footnotes should be a pointer field. I didn&#39;t notice my error as go translated my pointer-method calls on
-non-pointer values rather than complaining - i.e. <code class="verbatim">footnotes.add()</code> transparently gets translated to <code class="verbatim">(&amp;footnotes).add()</code> (<a href="https://golang.org/ref/spec#Calls">docs</a>).</p>
-</li>
-<li>
-<p>Headlines have to be htmlified twice - once for the outline and once for the headline itself. To do so we have to copy the writer</p>
-</li>
-<li>
-<p>Copying the writer copies footnotes - which contains a map and a slice. Changes to the map will always be reflected in the original map.
-Changes to the slice will only be reflected if the slice doesn&#39;t grow.</p>
-</li>
-<li>
-<p>We can thus end up with a footnote being in the mapping but not the slice - and get an index out of range error.</p>
-</li>
+<li>HTMLWriter.footnotes should be a pointer field. I didn&#39;t notice my error as go translated my pointer-method calls on
+non-pointer values rather than complaining - i.e. <code class="verbatim">footnotes.add()</code> transparently gets translated to <code class="verbatim">(&amp;footnotes).add()</code> (<a href="https://golang.org/ref/spec#Calls">docs</a>).</li>
+<li>Headlines have to be htmlified twice - once for the outline and once for the headline itself. To do so we have to copy the writer</li>
+<li>Copying the writer copies footnotes - which contains a map and a slice. Changes to the map will always be reflected in the original map.
+Changes to the slice will only be reflected if the slice doesn&#39;t grow.</li>
+<li>We can thus end up with a footnote being in the mapping but not the slice - and get an index out of range error.</li>
 </ul>
 </div>
 </div>

--- a/org/testdata/headlines.html
+++ b/org/testdata/headlines.html
@@ -24,17 +24,11 @@ Simple Headline <code class="statistic">[1/2]</code>
 </h2>
 <div id="outline-text-headline-1" class="outline-text-2">
 <ul>
-<li class="checked">
-<p>checked</p>
-</li>
-<li class="unchecked">
-<p>unchecked</p>
-</li>
-<li>
-<p>note that statistic tokens are marked up anywhere
+<li class="checked">checked</li>
+<li class="unchecked">unchecked</li>
+<li>note that statistic tokens are marked up anywhere
 not just where they are actually meant to be - even here &gt; <code class="statistic">[100%]</code> &lt;
-(Org mode proper does the same)</p>
-</li>
+(Org mode proper does the same)</li>
 </ul>
 </div>
 </div>

--- a/org/testdata/inline.html
+++ b/org/testdata/inline.html
@@ -1,42 +1,22 @@
 <ul>
-<li>
-<p><em>emphasis</em> and a hard line break <br>
+<li><em>emphasis</em> and a hard line break <br>
 see? <br>
-also hard line breaks not followed by a newline get ignored, see \\</p>
-</li>
-<li>
-<p><em>.emphasis with dot border chars.</em></p>
-</li>
-<li>
-<p><em>emphasis with a slash/inside</em></p>
-</li>
-<li>
-<p><em>emphasis</em> followed by raw text with slash /</p>
-</li>
-<li>
-<p>-&gt;/not an emphasis/&lt;-</p>
-</li>
-<li>
-<p>links with slashes do not become <em>emphasis</em>: <a href="https://somelinkshouldntrenderaccidentalemphasis.com">https://somelinkshouldntrenderaccidentalemphasis.com</a>/ <em>emphasis</em></p>
-</li>
-<li>
-<p><span style="text-decoration: underline;">underlined</span> <strong>bold</strong>  <code class="verbatim">verbatim</code> <code>code</code> <del>strikethrough</del></p>
-</li>
-<li>
-<p><strong>bold string with an *asterisk inside</strong></p>
-</li>
-<li>
-<p>inline source blocks like <div class="src src-inline src-html">
+also hard line breaks not followed by a newline get ignored, see \\</li>
+<li><em>.emphasis with dot border chars.</em></li>
+<li><em>emphasis with a slash/inside</em></li>
+<li><em>emphasis</em> followed by raw text with slash /</li>
+<li>-&gt;/not an emphasis/&lt;-</li>
+<li>links with slashes do not become <em>emphasis</em>: <a href="https://somelinkshouldntrenderaccidentalemphasis.com">https://somelinkshouldntrenderaccidentalemphasis.com</a>/ <em>emphasis</em></li>
+<li><span style="text-decoration: underline;">underlined</span> <strong>bold</strong>  <code class="verbatim">verbatim</code> <code>code</code> <del>strikethrough</del></li>
+<li><strong>bold string with an *asterisk inside</strong></li>
+<li>inline source blocks like <div class="src src-inline src-html">
 <div class="highlight-inline">
 <pre>
 &lt;h1&gt;hello&lt;/h1&gt;
 </pre>
 </div>
-</div></p>
-</li>
-<li>
-<p>inline export blocks <h1>hello</h1></p>
-</li>
+</div></li>
+<li>inline export blocks <h1>hello</h1></li>
 <li>
 <p><code class="verbatim">multiline emphasis is
 supported - and respects MaxEmphasisNewLines (default: 1)</code>
@@ -48,68 +28,32 @@ this
 is
 not emphasized/</p>
 </li>
-<li>
-<p>empty emphasis markers like ++ // __ and so on are ignored</p>
-</li>
-<li>
-<p>use _{} for subscript<sub>sub</sub> and ^{} for superscript<sup>super</sup></p>
-</li>
+<li>empty emphasis markers like ++ // __ and so on are ignored</li>
+<li>use _{} for subscript<sub>sub</sub> and ^{} for superscript<sup>super</sup></li>
 <li>
 <p>links</p>
 <ol>
-<li>
-<p>regular link <a href="https://example.com">https://example.com</a> link without description</p>
-</li>
-<li>
-<p>regular link <a href="https://example.com">example.com</a> link with description</p>
-</li>
-<li>
-<p>regular link to a file (image) <img src="my-img.png" alt="my-img.png" title="my-img.png" /></p>
-</li>
-<li>
-<p>regular link to an org file (extension replaced with html) <a href="inline.html">inline.html</a> / <a href="../testdata/inline.html">../testdata/inline.html</a></p>
-</li>
-<li>
-<p>regular link to a file (video) <video src="my-video.mp4" title="my-video.mp4">my-video.mp4</video></p>
-</li>
-<li>
-<p>regular link to http (image) <img src="http://placekitten.com/200/200#.png" alt="http://placekitten.com/200/200#.png" title="http://placekitten.com/200/200#.png" /></p>
-</li>
-<li>
-<p>regular link to https (image) <img src="https://placekitten.com/200/200#.png" alt="https://placekitten.com/200/200#.png" title="https://placekitten.com/200/200#.png" /></p>
-</li>
-<li>
-<p>regular link with image as description <a href="https://placekitten.com"><img src="https://placekitten.com/200/200#.png" alt="https://placekitten.com/200/200#.png" /></a></p>
-</li>
-<li>
-<p>regular link enclosed in [] [<a href="https://www.example.com">https://www.example.com</a>] [<a href="https://www.example.com">example.com</a>]</p>
-</li>
-<li>
-<p>auto link, i.e. not inside <code class="verbatim">\[[square brackets]\]</code> <a href="https://www.example.com">https://www.example.com</a></p>
-</li>
+<li>regular link <a href="https://example.com">https://example.com</a> link without description</li>
+<li>regular link <a href="https://example.com">example.com</a> link with description</li>
+<li>regular link to a file (image) <img src="my-img.png" alt="my-img.png" title="my-img.png" /></li>
+<li>regular link to an org file (extension replaced with html) <a href="inline.html">inline.html</a> / <a href="../testdata/inline.html">../testdata/inline.html</a></li>
+<li>regular link to a file (video) <video src="my-video.mp4" title="my-video.mp4">my-video.mp4</video></li>
+<li>regular link to http (image) <img src="http://placekitten.com/200/200#.png" alt="http://placekitten.com/200/200#.png" title="http://placekitten.com/200/200#.png" /></li>
+<li>regular link to https (image) <img src="https://placekitten.com/200/200#.png" alt="https://placekitten.com/200/200#.png" title="https://placekitten.com/200/200#.png" /></li>
+<li>regular link with image as description <a href="https://placekitten.com"><img src="https://placekitten.com/200/200#.png" alt="https://placekitten.com/200/200#.png" /></a></li>
+<li>regular link enclosed in [] [<a href="https://www.example.com">https://www.example.com</a>] [<a href="https://www.example.com">example.com</a>]</li>
+<li>auto link, i.e. not inside <code class="verbatim">\[[square brackets]\]</code> <a href="https://www.example.com">https://www.example.com</a></li>
 </ol>
 </li>
 <li>
 <p>timestamps</p>
 <ul>
-<li>
-<p><span class="timestamp">&lt;2019-01-06 Sun&gt;</span></p>
-</li>
-<li>
-<p><span class="timestamp">&lt;2019-01-06 Sun&gt;</span></p>
-</li>
-<li>
-<p><span class="timestamp">&lt;2019-01-06 Sun 18:00&gt;</span></p>
-</li>
-<li>
-<p><span class="timestamp">&lt;2019-01-06 Sun 18:00 +1w&gt;</span></p>
-</li>
-<li>
-<p><span class="timestamp">&lt;2019-01-06 Sun 18:00&gt;</span></p>
-</li>
-<li>
-<p><span class="timestamp">&lt;2019-01-06 Sun 18:00 +1w&gt;</span></p>
-</li>
+<li><span class="timestamp">&lt;2019-01-06 Sun&gt;</span></li>
+<li><span class="timestamp">&lt;2019-01-06 Sun&gt;</span></li>
+<li><span class="timestamp">&lt;2019-01-06 Sun 18:00&gt;</span></li>
+<li><span class="timestamp">&lt;2019-01-06 Sun 18:00 +1w&gt;</span></li>
+<li><span class="timestamp">&lt;2019-01-06 Sun 18:00&gt;</span></li>
+<li><span class="timestamp">&lt;2019-01-06 Sun 18:00 +1w&gt;</span></li>
 </ul>
 </li>
 <li>

--- a/org/testdata/latex.html
+++ b/org/testdata/latex.html
@@ -1,27 +1,13 @@
 <p>without latex delimiters the <code class="verbatim">_{i=1}</code> in <code class="verbatim">\sum_{i=1}^n a_n</code> is interpreted as subscript.
 we support <code class="verbatim">\(...\)</code>, <code class="verbatim">\[...\]</code>, <code class="verbatim">$$...$$</code> and <code class="verbatim">\begin{$env}...\end{$env}</code> as latex fragment delimiters.</p>
 <ul>
-<li>
-<p>∑<sub>i=1</sub>^n a_n (without latex delimiter)</p>
-</li>
-<li>
-<p>\(\sum_{i=1}^n a_n\)</p>
-</li>
-<li>
-<p>\[\sum_{i=1}^n a_n\]</p>
-</li>
-<li>
-<p>$$\sum_{i=1}^n a_n$$</p>
-</li>
-<li>
-<p>\begin{xyz}\sum_{i=1}^n a_n\end{xyz}</p>
-</li>
-<li>
-<p>\begin{xyz}
+<li>∑<sub>i=1</sub>^n a_n (without latex delimiter)</li>
+<li>\(\sum_{i=1}^n a_n\)</li>
+<li>\[\sum_{i=1}^n a_n\]</li>
+<li>$$\sum_{i=1}^n a_n$$</li>
+<li>\begin{xyz}\sum_{i=1}^n a_n\end{xyz}</li>
+<li>\begin{xyz}
 \sum_{i=1}^n a_n
-\end{xyz}</p>
-</li>
-<li>
-<p>$2 + 2$, $3 - 3$</p>
-</li>
+\end{xyz}</li>
+<li>$2 + 2$, $3 - 3$</li>
 </ul>

--- a/org/testdata/lists.html
+++ b/org/testdata/lists.html
@@ -1,36 +1,22 @@
 <ul>
-<li class="unchecked">
-<p>unordered list item 1</p>
-</li>
+<li class="unchecked">unordered list item 1</li>
 <li>
-<p>
 list item with empty first and second line <br>
-normally an empty line breaks the list item - but we make an exception for the first line and don&#39;t count it towards that limit</p>
-</li>
+normally an empty line breaks the list item - but we make an exception for the first line and don&#39;t count it towards that limit</li>
 <li>
 <p>unordered list item 2 - with <code>inline</code> <em>markup</em></p>
 <ol>
 <li class="indeterminate">
 <p>ordered sublist item 1</p>
 <ol>
-<li class="checked">
-<p>ordered sublist item 1</p>
-</li>
-<li class="unchecked">
-<p>ordered sublist item 2</p>
-</li>
-<li class="checked">
-<p>ordered sublist item 3</p>
-</li>
+<li class="checked">ordered sublist item 1</li>
+<li class="unchecked">ordered sublist item 2</li>
+<li class="checked">ordered sublist item 3</li>
 </ol>
 </li>
+<li>ordered sublist item 2</li>
 <li>
-<p>ordered sublist item 2</p>
-</li>
-<li>
-<p>
-list item with empty first and second line - see above</p>
-</li>
+list item with empty first and second line - see above</li>
 </ol>
 </li>
 <li class="checked">
@@ -85,23 +71,17 @@ descriptive lists</p>
 <dt class="unchecked">
 term
 </dt>
-<dd>
-<p>details
-continued details</p>
-</dd>
+<dd>details
+continued details</dd>
 <dt class="unchecked">
 ?
 </dt>
-<dd>
-<p>details without a term</p>
-</dd>
+<dd>details without a term</dd>
 <dt class="checked">
 term
 </dt>
 <dd>
-<p>
-details on a new line</p>
-</dd>
+details on a new line</dd>
 <dt>
 term
 </dt>
@@ -120,89 +100,51 @@ echo &#34;Hello World!&#34;
 </dl>
 <p>some list termination tests</p>
 <ul>
-<li>
-<p>unordered 1</p>
-</li>
-<li>
-<p>unordered 2</p>
-</li>
+<li>unordered 1</li>
+<li>unordered 2</li>
 </ul>
 <ol>
-<li>
-<p>ordered 1</p>
-</li>
-<li>
-<p>ordered 2</p>
-</li>
+<li>ordered 1</li>
+<li>ordered 2</li>
 </ol>
 <ol>
-<li>
-<p>ordered 1</p>
-</li>
-<li>
-<p>ordered 2</p>
-</li>
+<li>ordered 1</li>
+<li>ordered 2</li>
 </ol>
 <ul>
-<li>
-<p>unordered 1</p>
-</li>
-<li>
-<p>unordered 2</p>
-</li>
+<li>unordered 1</li>
+<li>unordered 2</li>
 </ul>
 <ol>
-<li>
-<p>ordered 1</p>
-</li>
-<li>
-<p>ordered 2</p>
-</li>
+<li>ordered 1</li>
+<li>ordered 2</li>
 </ol>
 <dl>
 <dt>
 unordered descriptive
 </dt>
-<dd>
-<p>1</p>
-</dd>
+<dd>1</dd>
 <dt>
 unordered descriptive
 </dt>
-<dd>
-<p>2</p>
-</dd>
+<dd>2</dd>
 </dl>
 <dl>
 <dt>
 ordered descriptive
 </dt>
-<dd>
-<p>1</p>
-</dd>
+<dd>1</dd>
 <dt>
 ordered descriptive
 </dt>
-<dd>
-<p>2</p>
-</dd>
+<dd>2</dd>
 </dl>
 <ul>
-<li>
-<p>unordered 1</p>
-</li>
-<li>
-<p>unordered 2</p>
-</li>
+<li>unordered 1</li>
+<li>unordered 2</li>
 </ul>
 <ol>
-<li value="2">
-<p>use `[@n]` to change the value of list items</p>
-</li>
-<li class="unchecked">
-<p>foobar</p>
-</li>
-<li value="10" class="checked">
-<p>that even works in combination with list statuses (`[ ]`)</p>
-</li>
+<li value="2">use `[@n]` to change the value of list items</li>
+<li class="unchecked">foobar</li>
+<li value="10" class="checked">that even works in combination with list statuses (`[ ]`)</li>
 </ol>

--- a/org/testdata/misc.html
+++ b/org/testdata/misc.html
@@ -274,21 +274,11 @@ jobs:
 </h4>
 <div id="outline-text-headline-8" class="outline-text-4">
 <ul>
-<li>
-<p>ndash –</p>
-</li>
-<li>
-<p>mdash —</p>
-</li>
-<li>
-<p>ellipsis …</p>
-</li>
-<li>
-<p>acute Á and so on</p>
-</li>
-<li>
-<p>note that —— is replaced with 2 mdashes and …. becomes ellipsis+. and so on - that&#39;s how org also does it</p>
-</li>
+<li>ndash –</li>
+<li>mdash —</li>
+<li>ellipsis …</li>
+<li>acute Á and so on</li>
+<li>note that —— is replaced with 2 mdashes and …. becomes ellipsis+. and so on - that&#39;s how org also does it</li>
 </ul>
 </div>
 </div>
@@ -310,27 +300,19 @@ or <code>that</code> foo.</p>
 </h4>
 <div id="outline-text-headline-10" class="outline-text-4">
 <ul>
-<li>
-<p>this list item
+<li>this list item
 has
 multiple
-linbreaks - but it&#39;s still just one paragraph (i.e. no line breaks are rendered)</p>
-</li>
-<li>
-<p>foobar</p>
-</li>
+linbreaks - but it&#39;s still just one paragraph (i.e. no line breaks are rendered)</li>
+<li>foobar</li>
 </ul>
 <ol>
-<li>
-<p>same
+<li>same
 goes
 for
 ordered
-lists</p>
-</li>
-<li>
-<p>foo</p>
-</li>
+lists</li>
+<li>foo</li>
 </ol>
 </div>
 </div>
@@ -364,9 +346,7 @@ lists</p>
 <li>
 <p>bullet 1</p>
 <ul>
-<li>
-<p>sub bullet</p>
-</li>
+<li>sub bullet</li>
 </ul>
 </li>
 </ul>
@@ -438,18 +418,12 @@ Bar
 <div id="outline-text-headline-21" class="outline-text-4">
 <p>just like #46</p>
 <ul>
-<li>
-<p><code class="verbatim">--</code> -&gt; – (en dash)</p>
-</li>
-<li>
-<p><code class="verbatim">---</code> -&gt; — (em dash)</p>
-</li>
+<li><code class="verbatim">--</code> -&gt; – (en dash)</li>
+<li><code class="verbatim">---</code> -&gt; — (em dash)</li>
 </ul>
 <p>also, consecutive dashes inside</p>
 <ul>
-<li>
-<p>inline code <code class="verbatim">--</code> <code class="verbatim">---</code> and verbatim <code>--</code> <code>---</code></p>
-</li>
+<li>inline code <code class="verbatim">--</code> <code class="verbatim">---</code> and verbatim <code>--</code> <code>---</code></li>
 <li>
 <p>src/example/export blocks should not be converted!</p>
 <div class="src src-sh">
@@ -579,9 +553,7 @@ list items don&#39;t end on child headline
 </h4>
 <div id="outline-text-headline-31" class="outline-text-4">
 <ul>
-<li>
-<p>a list item</p>
-</li>
+<li>a list item</li>
 </ul>
 <div id="outline-container-headline-32" class="outline-5">
 <h5 id="headline-32">
@@ -589,9 +561,7 @@ followed by a child headline
 </h5>
 <div id="outline-text-headline-32" class="outline-text-5">
 <ul>
-<li>
-<p>followed by another list item</p>
-</li>
+<li>followed by another list item</li>
 </ul>
 </div>
 </div>
@@ -612,12 +582,8 @@ Footnotes
 <div class="footnote-body">
 <p>a footnote <em>with</em> <strong>markup</strong></p>
 <ul>
-<li>
-<p>and a <strong>list</strong></p>
-</li>
-<li>
-<p>because that&#39;s possible</p>
-</li>
+<li>and a <strong>list</strong></li>
+<li>because that&#39;s possible</li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
This also removes extra newlines for simple list items, see changes to tests for details.

Closes #57