### PR TITLE
Emit id="some-descriptive-id" instead of id="headline-1"

### DIFF
--- a/org/document.go
+++ b/org/document.go
@@ -40,6 +40,7 @@ type Document struct {
 	Links          map[string]string
 	Nodes          []Node
 	NamedNodes     map[string]Node
+	Ids            map[string]bool
 	Outline        Outline           // Outline is a Table Of Contents for the document and contains all sections (headline + content).
 	BufferSettings map[string]string // Settings contains all settings that were parsed from keywords.
 	Error          error
@@ -123,6 +124,7 @@ func (c *Configuration) Parse(input io.Reader, path string) (d *Document) {
 		Outline:        Outline{outlineSection, outlineSection, 0},
 		BufferSettings: map[string]string{},
 		NamedNodes:     map[string]Node{},
+		Ids:            map[string]bool{},
 		Links:          map[string]string{},
 		Macros:         map[string]string{},
 		Path:           path,

--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -235,7 +235,7 @@ func (w *HTMLWriter) writeSection(section *Section, maxLvl int) {
 	w.WriteString("<li>")
 	h := section.Headline
 	title := cleanHeadlineTitleForHTMLAnchorRegexp.ReplaceAllString(w.WriteNodesAsString(h.Title...), "")
-	w.WriteString(fmt.Sprintf("<a href=\"#%s\">%s</a>\n", h.ID(), title))
+	w.WriteString(fmt.Sprintf("<a href=\"#%s\">%s</a>\n", h.ID(w.document), title))
 	hasChildren := false
 	for _, section := range section.Children {
 		hasChildren = hasChildren || maxLvl == 0 || section.Headline.Lvl <= maxLvl
@@ -255,8 +255,9 @@ func (w *HTMLWriter) WriteHeadline(h Headline) {
 		return
 	}
 
-	w.WriteString(fmt.Sprintf(`<div id="outline-container-%s" class="outline-%d">`, h.ID(), h.Lvl+1) + "\n")
-	w.WriteString(fmt.Sprintf(`<h%d id="%s">`, h.Lvl+1, h.ID()) + "\n")
+	id := h.ID(w.document)
+	w.WriteString(fmt.Sprintf(`<div id="outline-container-%s" class="outline-%d">`, id, h.Lvl+1) + "\n")
+	w.WriteString(fmt.Sprintf(`<h%d id="%s">`, h.Lvl+1, id) + "\n")
 	if w.document.GetOption("todo") != "nil" && h.Status != "" {
 		w.WriteString(fmt.Sprintf(`<span class="todo">%s</span>`, h.Status) + "\n")
 	}
@@ -275,7 +276,7 @@ func (w *HTMLWriter) WriteHeadline(h Headline) {
 	}
 	w.WriteString(fmt.Sprintf("\n</h%d>\n", h.Lvl+1))
 	if content := w.WriteNodesAsString(h.Children...); content != "" {
-		w.WriteString(fmt.Sprintf(`<div id="outline-text-%s" class="outline-text-%d">`, h.ID(), h.Lvl+1) + "\n" + content + "</div>\n")
+		w.WriteString(fmt.Sprintf(`<div id="outline-text-%s" class="outline-text-%d">`, h.ID(w.document), h.Lvl+1) + "\n" + content + "</div>\n")
 	}
 	w.WriteString("</div>\n")
 }


### PR DESCRIPTION
I don't expect this pull request to be accepted because the code isn't complete, but I thought I'd submit it for comment from Niklas.

I'd like my hugo site with org-mode files to support links such as

    /page#meaningful-anchor

So I attempted to modify go-org to do that, and I was moderately successful.  And while this commit will transform


    ** macosx

to

    <h2 id="macosx">

it does not properly handle headings that contain links.  For example, it will stupidly transform

    ** [[https://github.com/plujon/go-org][go-org]]

to

    <h2 id="https-github-com-plujon-go-org-go-org">

Other projects I know of that provide similar transformations are
gollum-lib and AnchorJS.  The former uses nokogiri (an html parser) to
strip tags before applying the transformation, and the latter uses the
browser's element.textContent().

Unfortunately, I'm not a Go programmer and I don't know how to iterate over the parsed nodes in go-org to make this work correctly in a reasonable amount of time.  So, I'm submitting this for feedback.

Possibly useful references:

https://github.com/gollum/gollum-lib/blob/f32a59d6e7c489e0f7a735987272fc23211e8092/lib/gollum-lib/filter/toc.rb#L109

https://github.com/bryanbraun/anchorjs/blob/e0f62ebb48c386c8aa3cf7a47cced5ef17f60e3c/anchor.js#L239