### PR TITLE
Rewrite blorg tests without external md5sum

### DIFF
--- a/blorg/config_test.go
+++ b/blorg/config_test.go
@@ -1,36 +1,87 @@
 package blorg
 
 import (
-	"fmt"
+	"bufio"
+	"crypto/md5"
+	"encoding/hex"
+	"io/fs"
 	"io/ioutil"
-	"os/exec"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestBlorg(t *testing.T) {
+	// Re-generate this file with `find testdata/public -type f | sort -u | xargs md5sum > testdata/public.md5`
+	hashFile, err := os.Open("testdata/public.md5")
+	if err != nil {
+		t.Errorf("Could not open hash file: %s", err)
+		return
+	}
+	defer hashFile.Close()
+	scanner := bufio.NewScanner(hashFile)
+	committedHashes := make(map[string]string)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) != 2 {
+			t.Errorf("Could not split hash entry line in 2: len(parts)=%d", len(parts))
+			return
+		}
+		hash := parts[0]
+		fileName := parts[1]
+		committedHashes[fileName] = hash
+	}
+	if err := scanner.Err(); err != nil {
+		t.Errorf("Failed to read hash file: %s", err)
+		return
+	}
+
 	config, err := ReadConfig("testdata/blorg.org")
 	if err != nil {
 		t.Errorf("Could not read config: %s", err)
-		return
-	}
-	committedHashBs, err := ioutil.ReadFile("testdata/public.md5")
-	if err != nil {
-		t.Errorf("Could not read hash bytes: %s", err)
 		return
 	}
 	if err := config.Render(); err != nil {
 		t.Errorf("Could not render: %s", err)
 		return
 	}
-	renderedHashBs, err := exec.Command("bash", "-c", fmt.Sprintf("find %s -type f | sort -u | xargs md5sum", config.PublicDir)).Output()
+
+	renderedFileHashes := make(map[string]string)
+	err = filepath.WalkDir(config.PublicDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		hash := md5.Sum(data)
+		renderedFileHashes[path] = hex.EncodeToString(hash[:])
+		return nil
+	})
 	if err != nil {
-		t.Errorf("Could not hash PublicDir: %s", err)
+		t.Errorf("Could not determine hashes of rendered files: %s", err)
 		return
 	}
-	rendered, committed := strings.TrimSpace(string(renderedHashBs)), strings.TrimSpace(string(committedHashBs))
-	if rendered != committed {
-		t.Errorf("PublicDir hashes do not match: '%s' -> '%s'", committed, rendered)
-		return
+
+	for file, rendered := range renderedFileHashes {
+		if _, ok := committedHashes[file]; !ok {
+			t.Errorf("New file %s does not have a committed hash", file)
+			continue
+		}
+		committed := committedHashes[file]
+		committedHashes[file] = "" // To check if there are missing files later.
+		if rendered != committed {
+			t.Errorf("PublicDir hashes do not match for %s: '%s' -> '%s'", file, committed, rendered)
+		}
+	}
+	for file, committed := range committedHashes {
+		if committed != "" {
+			t.Errorf("Missing file %s has a committed hash, but was not rendered", file)
+		}
 	}
 }

--- a/blorg/config_test.go
+++ b/blorg/config_test.go
@@ -23,7 +23,7 @@ func TestBlorg(t *testing.T) {
 		t.Errorf("Could not render: %s", err)
 		return
 	}
-	renderedHashBs, err := exec.Command("bash", "-c", fmt.Sprintf("find %s -type f | sort -u | xargs cat | md5sum", config.PublicDir)).Output()
+	renderedHashBs, err := exec.Command("bash", "-c", fmt.Sprintf("find %s -type f | sort -u | xargs md5sum", config.PublicDir)).Output()
 	if err != nil {
 		t.Errorf("Could not hash PublicDir: %s", err)
 		return

--- a/blorg/config_test.go
+++ b/blorg/config_test.go
@@ -14,7 +14,7 @@ func TestBlorg(t *testing.T) {
 		t.Errorf("Could not read config: %s", err)
 		return
 	}
-	commitedHashBs, err := ioutil.ReadFile("testdata/public.md5")
+	committedHashBs, err := ioutil.ReadFile("testdata/public.md5")
 	if err != nil {
 		t.Errorf("Could not read hash bytes: %s", err)
 		return
@@ -28,7 +28,7 @@ func TestBlorg(t *testing.T) {
 		t.Errorf("Could not hash PublicDir: %s", err)
 		return
 	}
-	rendered, committed := strings.TrimSpace(string(renderedHashBs)), strings.TrimSpace(string(commitedHashBs))
+	rendered, committed := strings.TrimSpace(string(renderedHashBs)), strings.TrimSpace(string(committedHashBs))
 	if rendered != committed {
 		t.Errorf("PublicDir hashes do not match: '%s' -> '%s'", committed, rendered)
 		return

--- a/blorg/testdata/public.md5
+++ b/blorg/testdata/public.md5
@@ -1,1 +1,10 @@
-ab73939658896f4b21a1486bd7862751  -
+a23f3b21b036af74ce0dc3b0f6a4d8d7  testdata/public/about.html
+b93d8331258932e6bb18d866329b5e4e  testdata/public/another-post.html
+a4e5753838107f8cf44f8dfabc577c04  testdata/public/index.html
+6e770ea67bb154191530585cc60c8c2f  testdata/public/some-post.html
+7a893b0b9b90974cd7d26cfcb0a22dd4  testdata/public/style.css
+3ac91ccf813551d639daed7fae8689ae  testdata/public/tags/another/index.html
+f780413c40454793f50722300113f234  testdata/public/tags/some/index.html
+967686d0550349659b60012f2449ef92  testdata/public/tags/static/index.html
+2180a6f960a21f02c41028b2a2d418d6  testdata/public/tags/yet/index.html
+be670bbbac7aec31b8f1563d944ea1ab  testdata/public/yet-another-post/index.html


### PR DESCRIPTION
It's a little bit longer, but avoids the need for external tools like `find` and `md5sum`.

I also made it produce a hash for each individual file, which makes it easier to determine which one changed.