### PR TITLE
Don't wrap simple titles in <p>

### DIFF
--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -100,7 +100,17 @@ func (w *HTMLWriter) Before(d *Document) {
 	if title := d.Get("TITLE"); title != "" && w.document.GetOption("title") != "nil" {
 		titleDocument := d.Parse(strings.NewReader(title), d.Path)
 		if titleDocument.Error == nil {
-			title = w.WriteNodesAsString(titleDocument.Nodes...)
+			simpleTitle := false
+			if len(titleDocument.Nodes) == 1 {
+				switch p := titleDocument.Nodes[0].(type) {
+				case Paragraph:
+					simpleTitle = true
+					title = w.WriteNodesAsString(p.Children...)
+				}
+			}
+			if !simpleTitle {
+				title = w.WriteNodesAsString(titleDocument.Nodes...)
+			}
 		}
 		w.WriteString(fmt.Sprintf(`<h1 class="title">%s</h1>`+"\n", title))
 	}

--- a/org/testdata/misc.html
+++ b/org/testdata/misc.html
@@ -1,5 +1,4 @@
-<h1 class="title"><p>Misc title <b>with an inline html export</b></p>
-</h1>
+<h1 class="title">Misc title <b>with an inline html export</b></h1>
 <nav>
 <ul>
 <li><a href="#headline-1">issues from goorgeous (free test cases, yay!)</a>


### PR DESCRIPTION
Before this commit, if an org document was titled "Title here", the
first line of HTML output would be as follows:
```html
<h1 class="title"><p>Title here</p>
</h1>
```
This commit changes the HTML writer to instead output the following:
```html
<h1 class="title">Title Here</h1>
```
I conversatively modified the code, so there might be more cases where
elements should be omitted from the title.