### PR TITLE
Allow customizing header level offset

### DIFF
--- a/org/html_writer_test.go
+++ b/org/html_writer_test.go
@@ -56,3 +56,50 @@ func TestPrettyRelativeLinks(t *testing.T) {
 		})
 	}
 }
+
+var topLevelHLevelTests = map[struct {
+	TopLevelHLevel int
+	input          string
+}]string{
+	{1, "* Top-level headline"}:        "<h1 id=\"headline-1\">\nTop-level headline\n</h1>",
+	{1, "** Second-level headline"}:    "<h2 id=\"headline-1\">\nSecond-level headline\n</h2>",
+	{1, "*** Third-level headline"}:    "<h3 id=\"headline-1\">\nThird-level headline\n</h3>",
+	{1, "**** Fourth-level headline"}:  "<h4 id=\"headline-1\">\nFourth-level headline\n</h4>",
+	{1, "***** Fifth-level headline"}:  "<h5 id=\"headline-1\">\nFifth-level headline\n</h5>",
+	{1, "****** Sixth-level headline"}: "<h6 id=\"headline-1\">\nSixth-level headline\n</h6>",
+
+	{2, "* Top-level headline"}:       "<h2 id=\"headline-1\">\nTop-level headline\n</h2>",
+	{2, "** Second-level headline"}:   "<h3 id=\"headline-1\">\nSecond-level headline\n</h3>",
+	{2, "*** Third-level headline"}:   "<h4 id=\"headline-1\">\nThird-level headline\n</h4>",
+	{2, "**** Fourth-level headline"}: "<h5 id=\"headline-1\">\nFourth-level headline\n</h5>",
+	{2, "***** Fifth-level headline"}: "<h6 id=\"headline-1\">\nFifth-level headline\n</h6>",
+
+	{3, "* Top-level headline"}:       "<h3 id=\"headline-1\">\nTop-level headline\n</h3>",
+	{3, "** Second-level headline"}:   "<h4 id=\"headline-1\">\nSecond-level headline\n</h4>",
+	{3, "*** Third-level headline"}:   "<h5 id=\"headline-1\">\nThird-level headline\n</h5>",
+	{3, "**** Fourth-level headline"}: "<h6 id=\"headline-1\">\nFourth-level headline\n</h6>",
+
+	{4, "* Top-level headline"}:     "<h4 id=\"headline-1\">\nTop-level headline\n</h4>",
+	{4, "** Second-level headline"}: "<h5 id=\"headline-1\">\nSecond-level headline\n</h5>",
+	{4, "*** Third-level headline"}: "<h6 id=\"headline-1\">\nThird-level headline\n</h6>",
+
+	{5, "* Top-level headline"}:     "<h5 id=\"headline-1\">\nTop-level headline\n</h5>",
+	{5, "** Second-level headline"}: "<h6 id=\"headline-1\">\nSecond-level headline\n</h6>",
+
+	{6, "* Top-level headline"}: "<h6 id=\"headline-1\">\nTop-level headline\n</h6>",
+}
+
+func TestTopLevelHLevel(t *testing.T) {
+	for org, expected := range topLevelHLevelTests {
+		t.Run(org.input, func(t *testing.T) {
+			writer := NewHTMLWriter()
+			writer.TopLevelHLevel = org.TopLevelHLevel
+			actual, err := New().Silent().Parse(strings.NewReader(org.input), "./topLevelHLevelTests.org").Write(writer)
+			if err != nil {
+				t.Errorf("TopLevelHLevel=%d %s\n got error: %s", org.TopLevelHLevel, org.input, err)
+			} else if actual := strings.TrimSpace(actual); !strings.Contains(actual, expected) {
+				t.Errorf("TopLevelHLevel=%d %s:\n%s'", org.TopLevelHLevel, org.input, diff(actual, expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows consumers to specify `TopLevelHLevel` to `HTMLWriter`, which works identically to Org's official [`:html-toplevel-hlevel` / `org-html-toplevel-hlevel`](https://orgmode.org/manual/Publishing-options.html) property. Default behavior is unchanged from current.

Fixes #94 :)