### PR TITLE
trim leading newline char on blocks for html

### DIFF
--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -622,7 +622,8 @@ func (w *HTMLWriter) blockContent(name string, children []Node) string {
 		WriteNodes(w, children...)
 		out := w.String()
 		w.Builder, w.htmlEscape = builder, htmlEscape
-		return strings.TrimRightFunc(out, unicode.IsSpace)
+
+		return strings.TrimRightFunc(strings.TrimLeftFunc(out, IsNewLineChar), unicode.IsSpace)
 	} else {
 		return w.WriteNodesAsString(children...)
 	}

--- a/org/testdata/blocks.html
+++ b/org/testdata/blocks.html
@@ -22,6 +22,16 @@ block caption
 <div class="src src-text">
 <div class="highlight">
 <pre>
+a source block with leading newline, trailing newline characters
+and a line started
+  with leading space
+	and line leading tab.
+</pre>
+</div>
+</div>
+<div class="src src-text">
+<div class="highlight">
+<pre>
 a source block without a language
 </pre>
 </div>

--- a/org/testdata/blocks.org
+++ b/org/testdata/blocks.org
@@ -13,6 +13,15 @@ hello
 #+END_SRC
 
 #+BEGIN_SRC
+
+a source block with leading newline, trailing newline characters
+and a line started
+  with leading space
+	and line leading tab.
+
+#+END_SRC
+
+#+BEGIN_SRC
 a source block without a language
 #+END_SRC
 

--- a/org/testdata/blocks.pretty_org
+++ b/org/testdata/blocks.pretty_org
@@ -13,6 +13,15 @@ hello
 #+END_SRC
 
 #+BEGIN_SRC
+
+a source block with leading newline, trailing newline characters
+and a line started
+  with leading space
+	and line leading tab.
+
+#+END_SRC
+
+#+BEGIN_SRC
 a source block without a language
 #+END_SRC
 

--- a/org/util.go
+++ b/org/util.go
@@ -68,3 +68,7 @@ func ParseRanges(s string) [][2]int {
 	}
 	return ranges
 }
+
+func IsNewLineChar(r rune) bool {
+	return r == '\n' || r == '\r'
+}


### PR DESCRIPTION
Basically trim the newline char when writing org blocks in HTML to prevent "padded" look on the `<pre>` elements.
See #101 