### PR TITLE
Making hr tags compatible with xml

### DIFF
--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -226,7 +226,7 @@ func (w *HTMLWriter) WriteFootnotes(d *Document) {
 		return
 	}
 	w.WriteString(`<div class="footnotes">` + "\n")
-	w.WriteString(`<hr class="footnotes-separatator">` + "\n")
+	w.WriteString(`<hr class="footnotes-separatator"/>` + "\n")
 	w.WriteString(`<div class="footnote-definitions">` + "\n")
 	for i, definition := range w.footnotes.list {
 		id := i + 1

--- a/org/testdata/footnotes.html
+++ b/org/testdata/footnotes.html
@@ -33,7 +33,7 @@ this is not part of <sup class="footnote-reference"><a id="footnote-reference-8"
 </div>
 </div>
 <div class="footnotes">
-<hr class="footnotes-separatator">
+<hr class="footnotes-separatator"/>
 <div class="footnote-definitions">
 <div class="footnote-definition">
 <sup id="footnote-1"><a href="#footnote-reference-1">1</a></sup>

--- a/org/testdata/footnotes_in_headline.html
+++ b/org/testdata/footnotes_in_headline.html
@@ -10,7 +10,7 @@ Title <sup class="footnote-reference"><a id="footnote-reference-1" href="#footno
 </h2>
 </div>
 <div class="footnotes">
-<hr class="footnotes-separatator">
+<hr class="footnotes-separatator"/>
 <div class="footnote-definitions">
 <div class="footnote-definition">
 <sup id="footnote-1"><a href="#footnote-reference-1">1</a></sup>

--- a/org/testdata/misc.html
+++ b/org/testdata/misc.html
@@ -574,7 +574,7 @@ Footnotes
 </h2>
 </div>
 <div class="footnotes">
-<hr class="footnotes-separatator">
+<hr class="footnotes-separatator"/>
 <div class="footnote-definitions">
 <div class="footnote-definition">
 <sup id="footnote-1"><a href="#footnote-reference-1">1</a></sup>


### PR DESCRIPTION
In the XML context, it is essential to ensure proper closure of the '<hr>' tags. Given that a significant portion of the blog post content is inserted into the '<content>' tag of the 'rss.xml,' a simple adjustment of adding the closing 'hr' tag can help alleviate potential challenges, especially when translating a page with footnotes into XML RSS. This minor modification can significantly contribute to a smoother workflow during content translation.