### PR TITLE
feat: Add support to autoformat org files with pre-commit.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: org-mode-autoformat
+  name: org-mode-autoformat
+  description: "Autoformats org-mode files."
+  entry: org-mode-autoformat.sh
+  language: docker
+  types: [file]
+  files: \.org$
+  minimum_pre_commit_version: 0.15.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:alpine
+
+RUN apk add git bash
+
+RUN mkdir /workdir
+RUN mkdir /app
+
+WORKDIR /app
+
+RUN go install github.com/niklasfasching/go-org@v1.7.0
+
+ADD org-mode-autoformat.sh /app/
+
+ENV PATH="${PATH}:/app"
+WORKDIR /workdir

--- a/README.org
+++ b/README.org
@@ -42,3 +42,16 @@ in general, have a look at the Makefile - it's short enough.
   - https://code.orgmode.org/bzg/org-mode/src/master/lisp/org-element.el
   - mostly those & ox-html.el, but yeah, all of [[https://code.orgmode.org/bzg/org-mode/src/master/lisp/]]
 - existing Org mode implementations: [[https://github.com/emacsmirror/org][org]], [[https://github.com/bdewey/org-ruby/blob/master/spec/html_examples][org-ruby]], [[https://github.com/chaseadamsio/goorgeous/][goorgeous]], [[https://github.com/jgm/pandoc/][pandoc]]
+
+
+** autoformat with pre-commit
+
+To run `go-org` autoformat as part of a [pre-commit][pre-commit] workflow, add something like the below to the `repos` list in the project's `.pre-commit-config.yaml`:
+
+#+begin_src yaml
+  - repo: https://github.com/niklasfasching/go-org
+    rev: v1.7.0
+    hooks:
+      - id: org-mode-autoformat
+        args: [--fix]
+#+end_src

--- a/org-mode-autoformat.sh
+++ b/org-mode-autoformat.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+fix=false
+
+if [[ $1 == "--fix" ]]; then
+	fix=true
+	shift
+fi
+
+changes=false
+
+for i in "$@"; do
+	tmp=$(mktemp)
+	go-org render "$i" org >"$tmp"
+
+	if ! diff "$i" "$tmp"; then
+		changes=true
+
+		if [[ $fix == true ]]; then
+			# overwrite input files
+			echo "fixing..."
+			mv "$tmp" "$i"
+		else
+			# show diff, do not overwrite
+			# diff "$i" "$tmp"
+			rm "$tmp"
+		fi
+
+	else
+		rm "$tmp"
+	fi
+
+done
+
+if [[ $changes == true ]]; then
+	exit 1
+else
+	exit 0
+fi


### PR DESCRIPTION
Pre-commit is a library to run checks and autoformat on committing. This allows using go-org to autoformat org files on commit.