### PR TITLE
Honour org :noweb strip-export parameter when writing HTML

### DIFF
--- a/org/document.go
+++ b/org/document.go
@@ -241,7 +241,7 @@ func (d *Document) parseOne(i int, stop stopFn) (consumed int, node Node) {
 	if consumed != 0 {
 		return consumed, node
 	}
-	d.Log.Printf("Could not parse token %#v: Falling back to treating it as plain text.", d.tokens[i])
+	d.Log.Printf("Could not parse token %#v in file %s: Falling back to treating it as plain text.", d.tokens[i], d.Path)
 	m := plainTextRegexp.FindStringSubmatch(d.tokens[i].matches[0])
 	d.tokens[i] = token{"text", len(m[1]), m[2], m}
 	return d.parseOne(i, stop)

--- a/org/html_writer.go
+++ b/org/html_writer.go
@@ -152,6 +152,10 @@ func (w *HTMLWriter) WriteBlock(b Block) {
 		if params[":exports"] == "results" || params[":exports"] == "none" {
 			break
 		}
+		if params[":noweb"] == "strip-export" {
+			stripNoweb := regexp.MustCompile(`<<[^>]+>>`)
+			content = stripNoweb.ReplaceAllString(content, "")
+		}
 		lang := "text"
 		if len(b.Parameters) >= 1 {
 			lang = strings.ToLower(b.Parameters[0])

--- a/org/org_writer_test.go
+++ b/org/org_writer_test.go
@@ -45,7 +45,7 @@ func testWriter(t *testing.T, newWriter func() Writer, ext string) {
 			if err != nil {
 				t.Fatalf("%s\n got error: %s", path, err)
 			} else if actual != expected {
-				t.Fatalf("%s:\n%s'", path, "")
+				t.Fatalf("%s:\n%s'", path, diff(actual, expected))
 			}
 		})
 	}

--- a/org/testdata/blocks.html
+++ b/org/testdata/blocks.html
@@ -195,3 +195,10 @@ Snow covers Emacs</p>
 </ul>
 </li>
 </ul>
+<div class="src src-raku">
+<div class="highlight">
+<pre>
+describe &lt;a b c&gt;;
+</pre>
+</div>
+</div>

--- a/org/testdata/blocks.org
+++ b/org/testdata/blocks.org
@@ -176,3 +176,7 @@ this unindented line is outside of the list item
 
         ---AlexSchroeder
     #+END_VERSE
+
+#+BEGIN_SRC raku :results output :noweb strip-export :exports both
+<<defn>>describe <a b c>;
+#+END_SRC

--- a/org/testdata/blocks.pretty_org
+++ b/org/testdata/blocks.pretty_org
@@ -176,3 +176,7 @@ this unindented line is outside of the list item
 
         ---AlexSchroeder
     #+END_VERSE
+
+#+BEGIN_SRC raku :results output :noweb strip-export :exports both
+<<defn>>describe <a b c>;
+#+END_SRC


### PR DESCRIPTION
This makes it possible to use noweb syntax and strip it from the generated HTML, e.g.

```
#+begin_src raku :results output :noweb strip-export :exports both
<<defn>>describe <a b c>;
#+end_src
```