### PR TITLE
Allow for multiple inline blocks in a paragraph

### DIFF
--- a/org/inline.go
+++ b/org/inline.go
@@ -73,7 +73,7 @@ var timestampRegexp = regexp.MustCompile(`^<(\d{4}-\d{2}-\d{2})( [A-Za-z]+)?( \d
 var footnoteRegexp = regexp.MustCompile(`^\[fn:([\w-]*?)(:(.*?))?\]`)
 var statisticsTokenRegexp = regexp.MustCompile(`^\[(\d+/\d+|\d+%)\]`)
 var latexFragmentRegexp = regexp.MustCompile(`(?s)^\\begin{(\w+)}(.*)\\end{(\w+)}`)
-var inlineBlockRegexp = regexp.MustCompile(`src_(\w+)(\[(.*)\])?{(.*)}`)
+var inlineBlockRegexp = regexp.MustCompile(`src_(\w+)(\[([^\]]*)\])?{([^}]*)}`)
 var inlineExportBlockRegexp = regexp.MustCompile(`@@(\w+):(.*?)@@`)
 var macroRegexp = regexp.MustCompile(`{{{(.*)\((.*)\)}}}`)
 

--- a/org/testdata/inline.html
+++ b/org/testdata/inline.html
@@ -18,6 +18,12 @@ also hard line breaks not followed by a newline get ignored, see \\</li>
 &lt;h1&gt;hello&lt;/h1&gt;
 </pre>
 </div>
+</div> and this <div class="src src-inline src-schema">
+<div class="highlight-inline">
+<pre>
+world
+</pre>
+</div>
 </div></li>
 <li>inline export blocks <h1>hello</h1></li>
 <li><code class="verbatim">multiline emphasis is

--- a/org/testdata/inline.org
+++ b/org/testdata/inline.org
@@ -11,7 +11,7 @@
 - links with slashes do not become /emphasis/: [[https://somelinkshouldntrenderaccidentalemphasis.com]]/ /emphasis/
 - _underlined_ *bold*  =verbatim= ~code~ +strikethrough+
 - *bold string with an *asterisk inside*
-- inline source blocks like src_html[:eval no]{<h1>hello</h1>}
+- inline source blocks like src_html[:eval no]{<h1>hello</h1>} and this src_schema[:eval no]{world}
 - inline export blocks @@html:<h1>hello</h1>@@
 - =multiline emphasis is
   supported - and respects MaxEmphasisNewLines (default: 1)=

--- a/org/testdata/inline.pretty_org
+++ b/org/testdata/inline.pretty_org
@@ -11,7 +11,7 @@
 - links with slashes do not become /emphasis/: [[https://somelinkshouldntrenderaccidentalemphasis.com]]/ /emphasis/
 - _underlined_ *bold*  =verbatim= ~code~ +strikethrough+
 - *bold string with an *asterisk inside*
-- inline source blocks like src_html[:eval no]{<h1>hello</h1>}
+- inline source blocks like src_html[:eval no]{<h1>hello</h1>} and this src_schema[:eval no]{world}
 - inline export blocks @@html:<h1>hello</h1>@@
 - =multiline emphasis is
   supported - and respects MaxEmphasisNewLines (default: 1)=


### PR DESCRIPTION
- Adjust the inlineBlock regex to match until the first `]` and `}`, this allows for multiple inline blocks to be present on the same line.
- Test added.