### PR TITLE
feat: allow for custom link resolving

### DIFF
--- a/org/document.go
+++ b/org/document.go
@@ -29,6 +29,7 @@ type Configuration struct {
 	DefaultSettings     map[string]string                     // Default values for settings that are overriden by setting the same key in BufferSettings.
 	Log                 *log.Logger                           // Log is used to print warnings during parsing.
 	ReadFile            func(filename string) ([]byte, error) // ReadFile is used to read e.g. #+INCLUDE files.
+	ResolveLink         func(protocol string, description []Node, link string) Node
 }
 
 // Document contains the parsing results and a pointer to the Configuration.
@@ -93,6 +94,9 @@ func New() *Configuration {
 		},
 		Log:      log.New(os.Stderr, "go-org: ", 0),
 		ReadFile: ioutil.ReadFile,
+		ResolveLink: func(protocol string, description []Node, link string) Node {
+			return RegularLink{protocol, description, link, false}
+		},
 	}
 }
 

--- a/org/inline.go
+++ b/org/inline.go
@@ -329,7 +329,7 @@ func (d *Document) parseRegularLink(input string, start int) (int, Node) {
 	if len(linkParts) == 2 {
 		protocol = linkParts[0]
 	}
-	return consumed, RegularLink{protocol, description, link, false}
+	return consumed, d.ResolveLink(protocol, description, link)
 }
 
 func (d *Document) parseTimestamp(input string, start int) (int, Node) {


### PR DESCRIPTION
This PR adds an extension point for resolving links in the document configuration.

My goal with this is to build a static site containing `[[denote:20240610T081524]]` style links.